### PR TITLE
Fix Deprecation Warning for Icons

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef} from "react";
-import {MagnifyingGlass} from "@phosphor-icons/react";
+import {MagnifyingGlassIcon} from "@phosphor-icons/react";
 
 
 type FilterOption = { value : number; label : string }
@@ -56,7 +56,7 @@ export const FilterBar : React.FC<FilterBarProps> = (
 				</div>
 				<div className="relative w-full sm:w-64">
 					{!searchTerm && <div>
-						<MagnifyingGlass
+						<MagnifyingGlassIcon
 							className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500"
 							size={20}
 						/>

--- a/src/components/HeadingWithBackButton.tsx
+++ b/src/components/HeadingWithBackButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {CaretCircleLeft} from "@phosphor-icons/react";
+import {CaretCircleLeftIcon} from "@phosphor-icons/react";
 import {useRouter} from "next/navigation";
 
 
@@ -33,7 +33,7 @@ export function HeadingWithBackButton(
 						className="mr-4"
 						aria-label={ariaLabel}
 				>
-					<CaretCircleLeft
+					<CaretCircleLeftIcon
 							size={40}
 							weight="bold"
 							className="text-primary text-teal-100 hover:text-teal-300 transition-colors duration-200"


### PR DESCRIPTION
## Description
[//]: # (Provide a brief description of the changes in this pull request)
Fixed deprecation warnings caused by newer version of phosphor icons.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## How Has This Been Tested?
[//]: # (Describe the tests you ran to verify your changes)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
[//]: # (Add any additional information or context about the pull request here)
