### PR TITLE
Regex Redirect for Old Bookmarks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,10 @@ const nextConfig = {
             source : "/modpack/terrafirmagreg/1.20.x_0.7.14/metals/:path*",
             destination : "/modpack/terrafirmagreg/1.20.x_0.7.x/metals/:path*",
             permanent : true
+        }, {
+            source : "/:type(modpack|mod)/:name([a-zA-Z]+)/:version([0-9x_.]+)",
+            destination : "/:type/:name/:version/metals",
+            permanent : true
         }]
     }
 }


### PR DESCRIPTION
## Description
Created a permanent redirect (308) for previous flat API setup which has been changed a while ago to `/metals`. This fix prevents a 404 from occurring for anyone who has the old variant bookmarked.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation update

## How Has This Been Tested?
[//]: # (Describe the tests you ran to verify your changes)
Tested manually

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
[//]: # (Add any additional information or context about the pull request here)
